### PR TITLE
Change host to hostname for IE compatibility

### DIFF
--- a/jquery.externalLinkWarning.js
+++ b/jquery.externalLinkWarning.js
@@ -7,7 +7,7 @@
             tmpLink.href = this.href;
             
             // check if anchor host matches top window host
-            var externalLink = (tmpLink.host !== top.location.host);
+            var externalLink = (tmpLink.hostname !== top.location.hostname);
             
             // if this is an external link, show confirmation dialog
             if (externalLink) {


### PR DESCRIPTION
We don't have a great explanation for it, but in IE `tmpLink.host` included port 80 while `top.location.host` did not. We changed both to `.hostname` so that it always grabs only the domain (without the port) for comparison.

cc: @grahamunr

Closes #1.
